### PR TITLE
Migrate some path operation to pathlib to fix potential bugs

### DIFF
--- a/batch_infer.py
+++ b/batch_infer.py
@@ -1,4 +1,6 @@
 import os
+import pathlib
+
 import torch
 import librosa
 import argparse
@@ -14,6 +16,7 @@ from ddsp.core import upsample
 from diffusion.vocoder import load_model_vocoder
 from tqdm import tqdm
 
+
 def traverse_dir(
         root_dir,
         extensions,
@@ -23,37 +26,36 @@ def traverse_dir(
         is_pure=False,
         is_sort=False,
         is_ext=True):
-
+    root_dir = pathlib.Path(root_dir)
     file_list = []
     cnt = 0
-    for root, _, files in os.walk(root_dir):
-        for file in files:
-            if any([file.endswith(f".{ext}") for ext in extensions]):
-                # path
-                mix_path = os.path.join(root, file)
-                pure_path = mix_path[len(root_dir)+1:] if is_pure else mix_path
+    for file in root_dir.rglob("*"):
+        if not any(file.suffix == f".{ext}" for ext in extensions):
+            continue
+        # path
+        pure_path = file.relative_to(root_dir)
+        mix_path = pure_path if is_pure else file
+        # check string
+        if (str_include is not None) and (str_include not in pure_path.as_posix()):
+            continue
+        if (str_exclude is not None) and (str_exclude in pure_path.as_posix()):
+            continue
+        # amount
+        if (amount is not None) and (cnt == amount):
+            if is_sort:
+                file_list.sort()
+            return file_list
 
-                # amount
-                if (amount is not None) and (cnt == amount):
-                    if is_sort:
-                        file_list.sort()
-                    return file_list
-                
-                # check string
-                if (str_include is not None) and (str_include not in pure_path):
-                    continue
-                if (str_exclude is not None) and (str_exclude in pure_path):
-                    continue
-                
-                if not is_ext:
-                    ext = pure_path.split('.')[-1]
-                    pure_path = pure_path[:-(len(ext)+1)]
-                file_list.append(pure_path)
-                cnt += 1
+        if not is_ext:
+            mix_path = mix_path.with_suffix('')
+        file_list.append(mix_path)
+        cnt += 1
+
     if is_sort:
         file_list.sort()
     return file_list
-    
+
+
 def check_args(ddsp_args, diff_args):
     if ddsp_args.data.sampling_rate != diff_args.data.sampling_rate:
         print("Unmatch data.sampling_rate!")
@@ -65,7 +67,8 @@ def check_args(ddsp_args, diff_args):
         print("Unmatch data.encoder!")
         return False
     return True
-    
+
+
 def parse_args(args=None, namespace=None):
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
@@ -213,23 +216,24 @@ def parse_args(args=None, namespace=None):
     return parser.parse_args(args=args, namespace=namespace)
 
 
-def infer(input_path, output_path, cmd, device, model, vocoder, args, ddsp, units_encoder):    
+def infer(input_path, output_path, cmd, device, model, vocoder, args, ddsp, units_encoder):
     # load input
     audio, sample_rate = librosa.load(input_path, sr=None)
     if len(audio.shape) > 1:
         audio = librosa.to_mono(audio)
     hop_size = args.data.block_size * sample_rate / args.data.sampling_rate
-    
+
     # get MD5 hash from wav file
     md5_hash = ""
     with open(input_path, 'rb') as f:
         data = f.read()
         md5_hash = hashlib.md5(data).hexdigest()
         print("MD5: " + md5_hash)
-    
+
     cache_dir_path = os.path.join(os.path.dirname(__file__), "cache")
-    cache_file_path = os.path.join(cache_dir_path, f"{cmd.pitch_extractor}_{hop_size}_{cmd.f0_min}_{cmd.f0_max}_{md5_hash}.npy")
-    
+    cache_file_path = os.path.join(cache_dir_path,
+                                   f"{cmd.pitch_extractor}_{hop_size}_{cmd.f0_min}_{cmd.f0_max}_{md5_hash}.npy")
+
     is_cache_available = os.path.exists(cache_file_path)
     if is_cache_available:
         # f0 cache load
@@ -239,40 +243,40 @@ def infer(input_path, output_path, cmd, device, model, vocoder, args, ddsp, unit
         # extract f0
         print('Pitch extractor type: ' + cmd.pitch_extractor)
         pitch_extractor = F0_Extractor(
-                            cmd.pitch_extractor, 
-                            sample_rate, 
-                            hop_size, 
-                            float(cmd.f0_min), 
-                            float(cmd.f0_max))
+            cmd.pitch_extractor,
+            sample_rate,
+            hop_size,
+            float(cmd.f0_min),
+            float(cmd.f0_max))
         print('Extracting the pitch curve of the input audio...')
-        f0 = pitch_extractor.extract(audio, uv_interp = True, device = device)
-        
+        f0 = pitch_extractor.extract(audio, uv_interp=True, device=device)
+
         # f0 cache save
         os.makedirs(cache_dir_path, exist_ok=True)
         np.save(cache_file_path, f0, allow_pickle=False)
-    
+
     f0 = torch.from_numpy(f0).float().to(device).unsqueeze(-1).unsqueeze(0)
-    
+
     # key change
     f0 = f0 * 2 ** (float(cmd.key) / 12)
-    
+
     # formant change
     formant_shift_key = torch.from_numpy(np.array([[float(cmd.formant_shift_key)]])).float().to(device)
-    
-    # extract volume 
+
+    # extract volume
     print('Extracting the volume envelope of the input audio...')
     volume_extractor = Volume_Extractor(hop_size)
     volume = volume_extractor.extract(audio)
     mask = (volume > 10 ** (float(cmd.threhold) / 20)).astype('float')
     mask = np.pad(mask, (4, 4), constant_values=(mask[0], mask[-1]))
-    mask = np.array([np.max(mask[n : n + 9]) for n in range(len(mask) - 8)])
+    mask = np.array([np.max(mask[n: n + 9]) for n in range(len(mask) - 8)])
     mask = torch.from_numpy(mask).float().to(device).unsqueeze(-1).unsqueeze(0)
     mask = upsample(mask, args.data.block_size).squeeze(-1)
     volume = torch.from_numpy(volume).float().to(device).unsqueeze(-1).unsqueeze(0)
-    
+
     input = torch.from_numpy(audio).float().unsqueeze(0).to(device)
     units = units_encoder.encode(input, sample_rate, hop_size)
-                            
+
     # speaker id or mix-speaker dictionary
     spk_mix_dict = literal_eval(cmd.spk_mix_dict)
     spk_id = torch.LongTensor(np.array([[int(cmd.spk_id)]])).to(device)
@@ -284,8 +288,8 @@ def infer(input_path, output_path, cmd, device, model, vocoder, args, ddsp, unit
         print('Mix-speaker mode')
     else:
         print('DDSP Speaker ID: '+ str(int(cmd.spk_id)))
-        print('Diffusion Speaker ID: '+ str(cmd.diff_spk_id)) 
-    
+        print('Diffusion Speaker ID: '+ str(cmd.diff_spk_id))
+
     # speed up
     if cmd.speedup == 'auto':
         infer_speedup = args.infer.speedup
@@ -300,7 +304,7 @@ def infer(input_path, output_path, cmd, device, model, vocoder, args, ddsp, unit
         print('Speed up: '+ str(infer_speedup))
     else:
         print('Sampling method: DDPM')
-    
+
     input_mel = None
     k_step = None
     if args.model.type == 'DiffusionNew':
@@ -320,48 +324,48 @@ def infer(input_path, output_path, cmd, device, model, vocoder, args, ddsp, unit
                 print('Extracting the mel spectrum of the input audio for shallow diffusion...')
                 audio_t = torch.from_numpy(audio).float().unsqueeze(0).to(device)
                 input_mel = vocoder.extract(audio_t, sample_rate)
-                input_mel = torch.cat((input_mel, input_mel[:,-1:,:]), 1)
+                input_mel = torch.cat((input_mel, input_mel[:, -1:, :]), 1)
         else:
             print('Shallow diffusion step is not identified, gaussian diffusion will be used!')
-        
+
     with torch.no_grad():
         if ddsp is not None:
             ddsp_f0 = 2 ** (-float(cmd.formant_shift_key) / 12) * f0
-            ddsp_output, _ , (_, _) = ddsp(units, ddsp_f0, volume, spk_id = spk_id, spk_mix_dict = spk_mix_dict)
+            ddsp_output, _, (_, _) = ddsp(units, ddsp_f0, volume, spk_id=spk_id, spk_mix_dict=spk_mix_dict)
             input_mel = vocoder.extract(ddsp_output, args.data.sampling_rate, keyshift=float(cmd.formant_shift_key))
         mel = model(
-                    units, 
-                    f0, 
-                    volume, 
-                    spk_id = diff_spk_id, 
-                    spk_mix_dict = spk_mix_dict,
-                    aug_shift = formant_shift_key,
-                    vocoder=vocoder,
-                    gt_spec=input_mel[:,:units.size(1)] if input_mel is not None else None,
-                    infer=True, 
-                    infer_speedup=infer_speedup, 
-                    method=method,
-                    k_step=k_step)
+            units,
+            f0,
+            volume,
+            spk_id=diff_spk_id,
+            spk_mix_dict=spk_mix_dict,
+            aug_shift=formant_shift_key,
+            vocoder=vocoder,
+            gt_spec=input_mel[:, :units.size(1)] if input_mel is not None else None,
+            infer=True,
+            infer_speedup=infer_speedup,
+            method=method,
+            k_step=k_step)
         output = vocoder.infer(mel, f0)
         output *= mask
         output = output.squeeze().cpu().numpy()
-        sf.write(output_path, output, args.data.sampling_rate)
+        sf.write(output_path, output[:audio.shape[0]], args.data.sampling_rate)
 
 
 if __name__ == '__main__':
     # parse commands
     cmd = parse_args()
-    
+
     # device
     device = cmd.device
     if device is None:
         device = 'cuda' if torch.cuda.is_available() else 'cpu'
-        
+
     extensions = cmd.extensions
-               
+
     # load diffusion model
     model, vocoder, args = load_model_vocoder(cmd.diff_ckpt, device=device)
-    
+
     ddsp = None
     if args.model.type == 'DiffusionNew':
         if cmd.ddsp_ckpt is not None:
@@ -372,7 +376,7 @@ if __name__ == '__main__':
                 ddsp = None
         else:
             print("DDSP model is not identified, the built-in DDSP model will be used!")
-    
+
     else:
         if cmd.k_step is not None and cmd.ddsp_ckpt is not None:
             # load ddsp model
@@ -380,29 +384,29 @@ if __name__ == '__main__':
             if not check_args(ddsp_args, args):
                 print("Cannot use this DDSP model for shallow diffusion, gaussian diffusion will be used!")
                 ddsp = None
-            
+
     # load units encoder
     if args.data.encoder == 'cnhubertsoftfish':
         cnhubertsoft_gate = args.data.cnhubertsoft_gate
     else:
         cnhubertsoft_gate = 10
     units_encoder = Units_Encoder(
-                        args.data.encoder, 
-                        args.data.encoder_ckpt, 
-                        args.data.encoder_sample_rate, 
-                        args.data.encoder_hop_size,
-                        cnhubertsoft_gate=cnhubertsoft_gate,
-                        device = device)
+        args.data.encoder,
+        args.data.encoder_ckpt,
+        args.data.encoder_sample_rate,
+        args.data.encoder_hop_size,
+        cnhubertsoft_gate=cnhubertsoft_gate,
+        device=device)
     wav_paths = traverse_dir(
-            cmd.input,
-            extensions=extensions,
-            is_pure=True,
-            is_sort=True,
-            is_ext=True
-        )
-    for path in wav_paths:
-        input_path = os.path.join(cmd.input, path)
-        output_path = os.path.join(cmd.output, os.path.splitext(path)[0]) + '.wav'
+        cmd.input,
+        extensions=extensions,
+        is_pure=True,
+        is_sort=True,
+        is_ext=True
+    )
+    for rel_path in tqdm(wav_paths):
+        input_path = pathlib.Path(cmd.input) / rel_path
+        output_path = (pathlib.Path(cmd.output) / rel_path).with_suffix('.wav')
         print('_______________________________')
-        print('Input: ' + input_path)
+        print('Input: ' + str(input_path))
         infer(input_path, output_path, cmd, device, model, vocoder, args, ddsp, units_encoder)

--- a/batch_infer.py
+++ b/batch_infer.py
@@ -361,7 +361,7 @@ def infer(input_path, output_path, cmd, device, model, vocoder, args, ddsp, unit
         output = vocoder.infer(mel, f0)
         output *= mask
         output = output.squeeze().cpu().numpy()
-        sf.write(output_path, output[:audio.shape[0]], args.data.sampling_rate)
+        sf.write(output_path, output, args.data.sampling_rate)
 
 
 if __name__ == '__main__':
@@ -416,7 +416,7 @@ if __name__ == '__main__':
         is_sort=True,
         is_ext=True
     )
-    for rel_path in wav_paths:
+    for rel_path in tqdm(wav_paths):
         input_path = pathlib.Path(cmd.input) / rel_path
         output_path = (pathlib.Path(cmd.output) / rel_path).with_suffix('.wav')
         print('_______________________________')

--- a/batch_infer.py
+++ b/batch_infer.py
@@ -19,13 +19,25 @@ from tqdm import tqdm
 
 def traverse_dir(
         root_dir,
-        extensions,
+        extensions: list,
         amount=None,
         str_include=None,
         str_exclude=None,
-        is_pure=False,
+        is_rel=False,
         is_sort=False,
-        is_ext=True):
+        is_ext=True
+):
+    """
+    Iterate the files matching the given condition in the given directory and its subdirectories.
+    :param root_dir: the root directory
+    :param extensions: a list of required file extensions (without ".")
+    :param amount: limit the number of files
+    :param str_include: require the relative path to include this string
+    :param str_exclude: require the relative path not to include this string
+    :param is_rel: whether to return the relative path instead of full path
+    :param is_sort: whether to sort the final results
+    :param is_ext: whether to reserve extensions in the filenames
+    """
     root_dir = pathlib.Path(root_dir)
     file_list = []
     cnt = 0
@@ -34,7 +46,7 @@ def traverse_dir(
             continue
         # path
         pure_path = file.relative_to(root_dir)
-        mix_path = pure_path if is_pure else file
+        mix_path = pure_path if is_rel else file
         # check string
         if (str_include is not None) and (str_include not in pure_path.as_posix()):
             continue
@@ -400,7 +412,7 @@ if __name__ == '__main__':
     wav_paths = traverse_dir(
         cmd.input,
         extensions=extensions,
-        is_pure=True,
+        is_rel=True,
         is_sort=True,
         is_ext=True
     )

--- a/batch_infer.py
+++ b/batch_infer.py
@@ -416,7 +416,7 @@ if __name__ == '__main__':
         is_sort=True,
         is_ext=True
     )
-    for rel_path in tqdm(wav_paths):
+    for rel_path in wav_paths:
         input_path = pathlib.Path(cmd.input) / rel_path
         output_path = (pathlib.Path(cmd.output) / rel_path).with_suffix('.wav')
         print('_______________________________')


### PR DESCRIPTION
## Potential bugs

When a path ending with `\` (on Windows) or `/` is given, some path operation, including string slicing and splitting, may produce wrong results after `os.path.join`. For example, if you join "D:\my_folder\\" or "D:\my_folder" with "my_file.wav", the result is always "D:\my_folder\my_file.wav", and if you slice the result from `len(my_folder)` or `len(my_folder) + 1` to get the filename, it can produce wrong results.

## Solution

The solution is to migrate path operations completely to `pathlib`. The above operations can simply be:

```python
import pathlib

my_folder = pathlib.Path("D:\my_folder\")
my_file = "my_file.wav"
full_path = my_folder / my_file  # equivalent to os.path.join
file_name = full_path.name  # will get "my_file.wav" correctly
```

## Changes in this PR

This PR modifies the function `traverse_dir` in `batch_infer.py`. It is now migrated to `pathlib` and returns `List[pathlib.Path]` instead of `List[str]`. One of its argument is renamed and the docstring is added.

I noticed there are several other `traverse_dir`s in this repository. I highly recommend that they all be migrate to `pathlib` to reduce the risks when doing path operations.