### PR TITLE
Fix the default_value of input_devices and output_devices in gui.py

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -218,10 +218,10 @@ class GUI:
             ],
             [sg.Frame(layout=[
                 [sg.Text(i18n("输入设备")),
-                 sg.Combo(input_devices, key='sg_input_device', default_value=input_devices[sd.default.device[0]],
+                 sg.Combo(input_devices, key='sg_input_device', default_value=input_devices[0],
                           enable_events=True)],
                 [sg.Text(i18n("输出设备")),
-                 sg.Combo(output_devices, key='sg_output_device', default_value=output_devices[sd.default.device[1]],
+                 sg.Combo(output_devices, key='sg_output_device', default_value=output_devices[0],
                           enable_events=True)]
             ], title=i18n('音频设备'))
             ],

--- a/gui_diff.py
+++ b/gui_diff.py
@@ -229,10 +229,10 @@ class GUI:
             ],
             [sg.Frame(layout=[
                 [sg.Text(i18n("输入设备")),
-                 sg.Combo(input_devices, key='sg_input_device', default_value=input_devices[sd.default.device[0]],
+                 sg.Combo(input_devices, key='sg_input_device', default_value=input_devices[0],
                           enable_events=True)],
                 [sg.Text(i18n("输出设备")),
-                 sg.Combo(output_devices, key='sg_output_device', default_value=output_devices[sd.default.device[1]],
+                 sg.Combo(output_devices, key='sg_output_device', default_value=output_devices[0],
                           enable_events=True)]
             ], title=i18n('音频设备'))
             ],


### PR DESCRIPTION
I don't currently have speakers or a microphone on my desktop. 
If I run gui.py in these conditions, I get an IndexError as shown in the screenshot.

I think the problem is caused by a mismatch between the index of default.device provided by sounddevice and the logic of dividing input_devices and output_devices in the get_devices function in gui.py.

I think most users will use the gui to select input device and output device, so it would be better to default to the 0th value of input_devices and output_devices for stability!


![Screenshot from 2023-10-26 10-03-15](https://github.com/yxlllc/DDSP-SVC/assets/56834479/6de88527-dc74-487a-ad0d-05ac6f02e7bf)
![Screenshot from 2023-10-26 10-06-00](https://github.com/yxlllc/DDSP-SVC/assets/56834479/0e47c10d-dedd-495a-b219-0bdcf7f9b59a)
