### PR TITLE
perf: Speed up validation step by removing unused STFT computations

### DIFF
--- a/reflow/solver.py
+++ b/reflow/solver.py
@@ -7,7 +7,6 @@ from logger.saver import Saver
 from logger import utils
 from torch import autocast
 from torch.cuda.amp import GradScaler
-from nsf_hifigan.nvSTFT import STFT
 
 def calculate_mel_snr(gt_mel, pred_mel):
     # 计算误差图像
@@ -128,24 +127,6 @@ def test(args, model, vocoder, loader_test, saver):
                 audio = librosa.to_mono(audio)
             audio = torch.from_numpy(audio).unsqueeze(0).to(signal)
             saver.log_audio({fn+'/gt.wav': audio, fn+'/pred.wav': signal})
-
-            WAV2MEL = STFT(
-                        sr=args.data.sampling_rate,
-                        n_mels=128,
-                        n_fft=2048,
-                        win_size=2048,
-                        hop_length=512,
-                        fmin=40,
-                        fmax=22050,
-                        clip_val=1e-5)
-            audio = audio.unsqueeze(0)
-            pre_mel = WAV2MEL.get_mel(signal[0, ...])
-            pre_mel = pre_mel.transpose(-1, -2)
-            gt_mel = WAV2MEL.get_mel(audio[0, ...])
-            gt_mel = gt_mel.transpose(-1, -2)
-            # 如果形状不同,裁剪使得形状相同
-            if pre_mel.shape[1] != gt_mel.shape[1]:
-                gt_mel = gt_mel[:, :pre_mel.shape[1], :]
 
             # 计算指标
             mel_val_mse_all += torch.nn.functional.mse_loss(mel, data['mel']).detach().cpu().numpy()


### PR DESCRIPTION
Removed the `WAV2MEL` computation and import of `STFT`, as the result of it is never used in the validation metric, this should speed up the validation process.